### PR TITLE
FIx broken link

### DIFF
--- a/comments/analyzer/go/stub.md
+++ b/comments/analyzer/go/stub.md
@@ -2,5 +2,5 @@ Remember to delete all the stub comments.
 Comments that are incorrect or irrelevant make it harder to read the code.
 
 Go developers take documentation [very seriously](https://golang.org/doc/effective_go.html#commentary).
-Every comment in the file should be something you would want to read on [https://godoc.org](godoc.org) if this were an official package.
+Every comment in the file should be something you would want to read on [https://godoc.org](https://godoc.org) if this were an official package.
 


### PR DESCRIPTION
The current link for godoc points to "godoc.org" (without "https://"), which gets interpreted as a relative link and is thus not working.