### PR TITLE
Add formatting checker and comment for Crystal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 sudo: false
 
 go:
-  - 1.5
+  - 1.6
   - tip
 
 install: true

--- a/analysis/crystal/crystal.go
+++ b/analysis/crystal/crystal.go
@@ -29,8 +29,8 @@ type response struct {
 }
 
 type problem struct {
-	Type   string
-	Result bool `json:"result,string"`
+	Type   string `json:"type"`
+	Result bool   `json:"result,string"`
 }
 
 // Analyze Crystal code for formatting errors (and, possibly, other bad things later).

--- a/analysis/crystal/crystal.go
+++ b/analysis/crystal/crystal.go
@@ -10,8 +10,12 @@ import (
 	"strings"
 )
 
-// Host is the base URL for the analysseur API.
-var Host string
+// Host is the base URL for the crystal-analyzer API.
+// Path is the endpoint for testing a file (default: "check").
+var (
+	Host string
+	Path = "check"
+)
 
 type request struct {
 	ID       string `json:"id"`
@@ -25,18 +29,18 @@ type response struct {
 }
 
 type problem struct {
-	Type   string `json:"type"`
-	Result string `json:"result"`
+	Type   string
+	Result bool `json:"result,string"`
 }
 
-// Analyze Crystal code for formatting errors (and other bad things maybe later)
+// Analyze Crystal code for formatting errors (and, possibly, other bad things later).
 func Analyze(files map[string]string) ([]string, error) {
 	var sources []string
 	for _, source := range files {
 		sources = append(sources, source)
 	}
 
-	url := fmt.Sprintf("%s/check", Host)
+	url := fmt.Sprintf("%s/%s", Host, Path)
 	code := strings.Join(sources, "\n")
 	requestBody := request{ID: "rikki", Contents: code}
 	requestBodyJSON, err := json.Marshal(requestBody)
@@ -76,7 +80,7 @@ func Analyze(files map[string]string) ([]string, error) {
 
 	var smells []string
 	for _, prob := range res.Problems {
-		if prob.Result == "true" {
+		if prob.Result == true {
 			smells = append(smells, prob.Type)
 		}
 	}

--- a/analysis/crystal/crystal.go
+++ b/analysis/crystal/crystal.go
@@ -59,14 +59,11 @@ func Analyze(files map[string]string) ([]string, error) {
 		return nil, fmt.Errorf("%s responded with status %d - %s\n", url, resp.StatusCode, string(body))
 	}
 
-	fmt.Printf("%#v\n", string(body))
 	var res result
 	err = json.Unmarshal(body, &res)
 	if err != nil {
 		return nil, err
 	}
-
-	fmt.Printf("%#v\n", res)
 
 	if res.Error != "" {
 		return nil, errors.New(res.Error)

--- a/analysis/crystal/crystal.go
+++ b/analysis/crystal/crystal.go
@@ -80,7 +80,7 @@ func Analyze(files map[string]string) ([]string, error) {
 
 	var smells []string
 	for _, prob := range res.Problems {
-		if prob.Result == true {
+		if prob.Result {
 			smells = append(smells, prob.Type)
 		}
 	}

--- a/analysis/crystal/crystal.go
+++ b/analysis/crystal/crystal.go
@@ -1,0 +1,83 @@
+package crystal
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+// Host is the base URL for the analysseur API.
+var Host string
+
+type result struct {
+	Problems []problem `json:"problems"`
+	Error    string    `json:"error"`
+}
+
+type problem struct {
+	Type   string `json:"type"`
+	Result string `json:"result"`
+}
+
+// Analyze Crystal code for formatting errors
+func Analyze(files map[string]string) ([]string, error) {
+	var sources []string
+	for _, source := range files {
+		sources = append(sources, source)
+	}
+
+	url := fmt.Sprintf("%s/check", Host)
+	codeBody := struct {
+		Code string `json:"code"`
+	}{
+		strings.Join(sources, "\n"),
+	}
+	codeBodyJSON, err := json.Marshal(codeBody)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewReader(codeBodyJSON))
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s responded with status %d - %s\n", url, resp.StatusCode, string(body))
+	}
+
+	fmt.Printf("%#v\n", string(body))
+	var res result
+	err = json.Unmarshal(body, &res)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("%#v\n", res)
+
+	if res.Error != "" {
+		return nil, errors.New(res.Error)
+	}
+
+	var smells []string
+	for _, prob := range res.Problems {
+		if prob.Result == "true" {
+			smells = append(smells, prob.Type)
+		}
+	}
+
+	return smells, nil
+}

--- a/analysis/crystal/crystal.go
+++ b/analysis/crystal/crystal.go
@@ -13,7 +13,13 @@ import (
 // Host is the base URL for the analysseur API.
 var Host string
 
-type result struct {
+type request struct {
+	ID       string `json:"id"`
+	Contents string `json:"contents"`
+}
+
+type response struct {
+	ID       string    `json:"id"`
 	Problems []problem `json:"problems"`
 	Error    string    `json:"error"`
 }
@@ -23,7 +29,7 @@ type problem struct {
 	Result string `json:"result"`
 }
 
-// Analyze Crystal code for formatting errors
+// Analyze Crystal code for formatting errors (and other bad things maybe later)
 func Analyze(files map[string]string) ([]string, error) {
 	var sources []string
 	for _, source := range files {
@@ -31,36 +37,35 @@ func Analyze(files map[string]string) ([]string, error) {
 	}
 
 	url := fmt.Sprintf("%s/check", Host)
-	codeBody := struct {
-		Code string `json:"code"`
-	}{
-		strings.Join(sources, "\n"),
-	}
-	codeBodyJSON, err := json.Marshal(codeBody)
+	code := strings.Join(sources, "\n")
+	requestBody := request{ID: "rikki", Contents: code}
+	requestBodyJSON, err := json.Marshal(requestBody)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", url, bytes.NewReader(codeBodyJSON))
+	req, err := http.NewRequest("POST", url, bytes.NewReader(requestBodyJSON))
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	respBody, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%s responded with status %d - %s\n", url, resp.StatusCode, string(body))
+		return nil, fmt.Errorf("%s responded with status %d - %s\n", url, resp.StatusCode, string(respBody))
 	}
 
-	var res result
-	err = json.Unmarshal(body, &res)
+	var res response
+	err = json.Unmarshal(respBody, &res)
 	if err != nil {
 		return nil, err
 	}

--- a/analysis/crystal/crystal_test.go
+++ b/analysis/crystal/crystal_test.go
@@ -1,0 +1,64 @@
+package crystal
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+)
+
+var (
+	u string
+)
+
+func init() {
+	Host = "http://localhost:3000"
+	u = fmt.Sprintf("%s/check", Host)
+}
+
+func TestFormattedCode(t *testing.T) {
+	mockJSON := `{"id":"rikki", "problems":[{"type":"unformatted", "result":"false"}], "error":""}`
+	result, err := getTestResponse(mockJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actual := len(result)
+	expected := 0
+	if actual != expected {
+		t.Errorf("got %v, want %v", actual, expected)
+	}
+}
+
+func TestUnformattedCode(t *testing.T) {
+	mockJSON := `{"id":"rikki", "problems":[{"type":"unformatted", "result":"true"}], "error":""}`
+	result, err := getTestResponse(mockJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actual := result[0]
+	expected := "unformatted"
+	if actual != expected {
+		t.Errorf("got %v, want %v", actual, expected)
+	}
+}
+
+func getTestResponse(mockJSON string) ([]string, error) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	mockRes := httpmock.NewStringResponder(200, mockJSON)
+	httpmock.RegisterResponder("POST", u, mockRes)
+
+	var files map[string]string
+	files = make(map[string]string)
+	files["test.cr"] = "code"
+
+	result, err := Analyze(files)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/analysis/crystal/crystal_test.go
+++ b/analysis/crystal/crystal_test.go
@@ -1,64 +1,53 @@
 package crystal
 
 import (
-	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
-
-	"github.com/jarcoal/httpmock"
 )
 
-var (
-	u string
-)
-
-func init() {
-	Host = "http://localhost:3000"
-	u = fmt.Sprintf("%s/check", Host)
-}
-
-func TestFormattedCode(t *testing.T) {
-	mockJSON := `{"id":"rikki", "problems":[{"type":"unformatted", "result":"false"}], "error":""}`
-	result, err := getTestResponse(mockJSON)
-	if err != nil {
-		t.Fatal(err)
+func TestAnalyze(t *testing.T) {
+	tests := []struct {
+		payload string
+		smells  []string
+	}{
+		{
+			`{"id":"rikki", "problems":[{"type":"unformatted", "result":"false"}], "error":""}`,
+			[]string{},
+		},
+		{
+			`{"id":"rikki", "problems":[{"type":"unformatted", "result":"true"}], "error":""}`,
+			[]string{"unformatted"},
+		},
 	}
 
-	actual := len(result)
-	expected := 0
-	if actual != expected {
-		t.Errorf("got %v, want %v", actual, expected)
+	for _, test := range tests {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(test.payload))
+		}))
+		defer ts.Close()
+
+		// Fake out the host and API endpoint.
+		Host = ts.URL
+		Path = ""
+
+		// Fake out the files to analyze. We only care what the server responds.
+		smells, err := Analyze(map[string]string{"test.cr": "code"})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(smells) != len(test.smells) {
+			t.Errorf("Got %d smells, expected %d", len(smells), len(test.smells))
+			continue
+		}
+
+		for i, smell := range smells {
+			if test.smells[i] != smell {
+				t.Errorf("Got smell %s at index %d, expected %s.", smell, i, test.smells[i])
+			}
+		}
 	}
-}
-
-func TestUnformattedCode(t *testing.T) {
-	mockJSON := `{"id":"rikki", "problems":[{"type":"unformatted", "result":"true"}], "error":""}`
-	result, err := getTestResponse(mockJSON)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	actual := result[0]
-	expected := "unformatted"
-	if actual != expected {
-		t.Errorf("got %v, want %v", actual, expected)
-	}
-}
-
-func getTestResponse(mockJSON string) ([]string, error) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-
-	mockRes := httpmock.NewStringResponder(200, mockJSON)
-	httpmock.RegisterResponder("POST", u, mockRes)
-
-	var files map[string]string
-	files = make(map[string]string)
-	files["test.cr"] = "code"
-
-	result, err := Analyze(files)
-	if err != nil {
-		return nil, err
-	}
-
-	return result, nil
 }

--- a/analyzer.go
+++ b/analyzer.go
@@ -6,10 +6,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/exercism/rikki/analysis/crystal"
 	"github.com/exercism/rikki/analysis/golang"
 	"github.com/exercism/rikki/analysis/ruby"
 	"github.com/jrallison/go-workers"
-	"github.com/mhelmetag/rikki/analysis/crystal"
 )
 
 // Analyzer is a job that provides feedback on specific issues in the code.

--- a/analyzer.go
+++ b/analyzer.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -104,7 +103,6 @@ func (analyzer *Analyzer) process(msg *workers.Msg) {
 		lgr.Printf("%s - %s", uuid, err)
 		return
 	}
-	fmt.Printf("%#v\n", smells)
 
 	// Log what we found.
 	sanity := log.New(os.Stdout, "SANITY: ", log.Ldate|log.Ltime|log.Lshortfile)

--- a/analyzer.go
+++ b/analyzer.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 	"github.com/exercism/rikki/analysis/golang"
 	"github.com/exercism/rikki/analysis/ruby"
 	"github.com/jrallison/go-workers"
+	"github.com/mhelmetag/rikki/analysis/crystal"
 )
 
 // Analyzer is a job that provides feedback on specific issues in the code.
@@ -91,6 +93,8 @@ func (analyzer *Analyzer) process(msg *workers.Msg) {
 		fn = ruby.Analyze
 	case "go":
 		fn = golang.Analyze
+	case "crystal":
+		fn = crystal.Analyze
 	default:
 		lgr.Printf("skipping - rikki- doesn't support %s\n", solution.TrackID)
 		return
@@ -100,6 +104,7 @@ func (analyzer *Analyzer) process(msg *workers.Msg) {
 		lgr.Printf("%s - %s", uuid, err)
 		return
 	}
+	fmt.Printf("%#v\n", smells)
 
 	// Log what we found.
 	sanity := log.New(os.Stdout, "SANITY: ", log.Ldate|log.Ltime|log.Lshortfile)

--- a/comments/analyzer/crystal/unformatted.md
+++ b/comments/analyzer/crystal/unformatted.md
@@ -1,0 +1,5 @@
+Hi! It looks like `crystal tool format` is complaining about your code's formatting.
+
+Instead of loosely following styleguides or using third party static code analyzers, developers (like you) can use Crystal's own formatter. It's there so we can enjoy the ease of Ruby syntax with the added benefit of consistency!
+
+Check it out and other cool Crystal tools [here](https://crystal-lang.org/2015/09/05/tools.html).

--- a/exercism.go
+++ b/exercism.go
@@ -86,7 +86,7 @@ func (e *Exercism) SubmitComment(comment []byte, uuid string) error {
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("cannot read response body %v - %s", resp, err)
+		return fmt.Errorf("cannot read response body %#v - %s", resp, err)
 	}
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusNoContent {

--- a/exercism.go
+++ b/exercism.go
@@ -85,6 +85,9 @@ func (e *Exercism) SubmitComment(comment []byte, uuid string) error {
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("cannot read response body %v - %s", resp, err)
+	}
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusNoContent {
 		return fmt.Errorf("%s responded with status %d - %s", url, resp.StatusCode, string(body))

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 var redisFlag = flag.String("redis", "redis://localhost:6379/0/", "Redis database to read queue from")
 var exercismFlag = flag.String("exercism", "http://localhost:4567", "Url of exercism api, e.g. http://exercism.io")
 var analysseurFlag = flag.String("analysseur", "http://localhost:8989", "Url of analysseur api, e.g. http://analysseur.exercism.io")
-var crystalcfsFlag = flag.String("crystalcfs", "http://localhost:3000", "Url of exercism_cfs api, e.g. http://exercism_cfs.exercism.io")
+var crystalAnalyzerFlag = flag.String("crystal-analyzer", "http://localhost:3000", "Url of crystal-analyzer api, e.g. http://crystal-analyzer.exercism.io")
 
 var lgr = log.New(os.Stdout, "ERROR: ", log.Ldate|log.Ltime|log.Lshortfile)
 
@@ -37,7 +37,7 @@ func main() {
 	exercism := NewExercism(*exercismFlag, NewAuth().Key())
 
 	ruby.Host = *analysseurFlag
-	crystal.Host = *crystalcfsFlag
+	crystal.Host = *crystalAnalyzerFlag
 
 	analyzer, err := NewAnalyzer(exercism, commentDir())
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/exercism/rikki/analysis/crystal"
 	"github.com/exercism/rikki/analysis/ruby"
 	"github.com/jrallison/go-workers"
-	"github.com/mhelmetag/rikki/analysis/crystal"
 )
 
 var redisFlag = flag.String("redis", "redis://localhost:6379/0/", "Redis database to read queue from")

--- a/main.go
+++ b/main.go
@@ -13,11 +13,13 @@ import (
 
 	"github.com/exercism/rikki/analysis/ruby"
 	"github.com/jrallison/go-workers"
+	"github.com/mhelmetag/rikki/analysis/crystal"
 )
 
 var redisFlag = flag.String("redis", "redis://localhost:6379/0/", "Redis database to read queue from")
 var exercismFlag = flag.String("exercism", "http://localhost:4567", "Url of exercism api, e.g. http://exercism.io")
 var analysseurFlag = flag.String("analysseur", "http://localhost:8989", "Url of analysseur api, e.g. http://analysseur.exercism.io")
+var crystalcfsFlag = flag.String("crystalcfs", "http://localhost:3000", "Url of exercism_cfs api, e.g. http://exercism_cfs.exercism.io")
 
 var lgr = log.New(os.Stdout, "ERROR: ", log.Ldate|log.Ltime|log.Lshortfile)
 
@@ -35,6 +37,7 @@ func main() {
 	exercism := NewExercism(*exercismFlag, NewAuth().Key())
 
 	ruby.Host = *analysseurFlag
+	crystal.Host = *crystalcfsFlag
 
 	analyzer, err := NewAnalyzer(exercism, commentDir())
 	if err != nil {


### PR DESCRIPTION
Aims to fix https://github.com/exercism/xcrystal/issues/30.

This was a bit of a mission but... I'm super stoked to have used Go and `delve` now.

I'm not reallly done... I mean it works but I have to deploy changes to the format checker API and I'd like to write a test or two but...

Here's my list of Todos:
- [x] Deployed new code to heroku
- [x] Write a test or two
- [x] Make sure error cases are handled correctly
- [x] Make travis happy
- [x] Rename crystal analyzer to crystal-analyzer (or similar)
- [ ] Work with @kytrinyx to get this folded into the ecosystem

Proof of comment:
![rikki_alive](https://cloud.githubusercontent.com/assets/8609429/19380947/65a3449e-91ae-11e6-9485-874cde92bc85.png)

Proof of Rikki picking up task from Redis:
<img width="884" alt="rikki_being_a_beast" src="https://cloud.githubusercontent.com/assets/8609429/19381295/d402d390-91af-11e6-9b0e-6b6b72ca1d5a.png">

After we get this folded into exercism, we should be able to kick off request to crystal-analyzer by editing this [file](https://github.com/exercism/exercism.io/blob/master/api/v1/routes/iterations.rb#L102-L103) in exercism.io.
